### PR TITLE
add @Override annotation

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
@@ -186,6 +186,7 @@ public class ChartFragment extends Fragment implements TrackDataHub.Listener {
         }
     }
 
+    @Override
     public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics) {
         if (isResumed()) {
             ChartPoint point = ChartPoint.create(trackStatistics, trackPoint, trackPoint.getSpeed(), chartByDistance, viewBinding.chartView.getUnitSystem());


### PR DESCRIPTION
Issue:
Add the "@OverRide" annotation above the method signature

File Location:
src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java

Description:
"@OverRide" should be used on overriding and implementing methods. While not mandatory, using the @OverRide annotation on compliant methods improves readability by making it explicit that methods are overriden.

A compliant method either overrides a parent method or implements an interface or abstract method.

Proposed Solution:
To prevent this issue to be persisting I have created the @OverRide annotation above the method.