### PR TITLE
Issue-18 private constructor added

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/sensors/BluetoothUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/BluetoothUtils.java
@@ -32,13 +32,15 @@ import de.dennisguse.opentracks.data.models.BatteryLevel;
  */
 public class BluetoothUtils {
 
+    private BluetoothUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static final UUID CLIENT_CHARACTERISTIC_CONFIG_UUID = new UUID(0x290200001000L, 0x800000805f9b34fbL);
 
     public static final ServiceMeasurementUUID BATTERY = new ServiceMeasurementUUID(
             new UUID(0x180F00001000L, 0x800000805f9b34fbL),
-            new UUID(0x2A1900001000L, 0x800000805f9b34fbL)
-    );
-
+            new UUID(0x2A1900001000L, 0x800000805f9b34fbL));
 
     private static final String TAG = BluetoothUtils.class.getSimpleName();
 


### PR DESCRIPTION

**Issue:**
Add a private constructor to hide the implicit public one. 

**File Location:**
src/main/java/de/dennisguse/opentracks/sensors/BluetoothUtils.java

**Description:**
Utility class is a class that only has static members, hence it should not be instantiated i.e. it shouldn't allow to create object of this class.

**Proposed Solution:**
To prevent instantiation we have created private constructor and it throws an Exception.