### PR TITLE
Removed deprecated code

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/sensors/SensorManager.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/SensorManager.java
@@ -104,11 +104,8 @@ public class SensorManager implements SharedPreferences.OnSharedPreferenceChange
         sensorDataSet.reset();
     }
 
-    @Deprecated
-    @VisibleForTesting
-    public void onChanged(Raw<?> data) {
-        listener.onChange(data);
-    }
+    
+    
 
     public GPSManager getGpsManager() {
         return gpsManager;


### PR DESCRIPTION
In the code, there is a deprecated method "onChanged" which does not need to be used. This method might not be compatible with the current code base or may have been replaced by an alternative. Removing such methods contributes to maintaining code readability. 